### PR TITLE
feat: Implement Terminating Recurring Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Schedular Application
 
 This is a Java application used to schedule or execute commands based on a defined pattern. 
@@ -7,9 +6,27 @@ This is a Java application used to schedule or execute commands based on a defin
 
 - **One-Time Schedule**: Supports tasks that need to be executed once at a specific time.
 - **Recurring Tasks**: Supports tasks that need to be executed repeatedly based on a minutes provide.
+- **Terminating Recurring Tasks**: Supports recurring tasks (minute-based) that automatically stop executing after a specified end date and time.
 
 The application is designed to handle scheduling efficiently and provides flexibility for different types of tasks.
 
+## Input Formats
+
+The application expects task definitions in the input file, one per line:
+
+-   **One-Time Task:** `MM DD HH mm YYYY <command_to_execute>`
+    *   Example: `30 20 11 05 2025 echo Process daily report`
+-   **Simple Recurring Task (no end date):** `*/<minutes> <command_to_execute>`
+    *   `<minutes>` should be between 1 and 1440.
+    *   Example: `*/15 echo Check server status`
+-   **Terminating Recurring Task (with end date):** `*/<minutes> <end_MM> <end_DD> <end_HH> <end_mm> <end_YYYY> <command_to_execute>`
+    *   `<minutes>` should be between 1 and 1440.
+    *   `<end_MM>`: End month (1-12)
+    *   `<end_DD>`: End day (1-31, valid for the month/year)
+    *   `<end_HH>`: End hour (0-23)
+    *   `<end_mm>`: End minute (0-59)
+    *   `<end_YYYY>`: End year (e.g., 2024)
+    *   Example: `*/30 12 31 17 00 2024 echo Perform cleanup, ends 31 Dec 2024 at 17:00`
 
 ## Assumptions
 - Terminal Commands to be executed are valid and can be run in the system's command line.

--- a/resource/Input.txt
+++ b/resource/Input.txt
@@ -12,3 +12,24 @@
 50 02 29 02 2025 echo Twelfth Task Feb 29th Date
 */300 echo Thirteen Task to be executed every 300 minutes
 */1441 echo Fourteen Task to be executed every 300 minutes
+# New Test Cases for TerminatingRecurringTask
+# Valid Cases
+*/1 01 01 00 05 2030 echo Runs every 1 min, ends Jan 1, 2030, 00:05
+*/2 12 31 23 59 2024 echo Runs every 2 mins, ends Dec 31, 2024, 23:59 (Set year to a near future year for testing)
+*/1 01 01 00 01 2020 echo Runs every 1 min, end time in the past (Set year to a past year)
+
+# Invalid Cases - RecurringWithEndDateParser Validations
+*/0 01 01 00 05 2030 echo Invalid minutes (0) for terminating task
+*/1500 01 01 00 05 2030 echo Invalid minutes (1500) for terminating task
+*/1 13 01 00 05 2030 echo Invalid end month (13) for terminating task
+*/1 01 32 00 05 2030 echo Invalid end day (32) for terminating task
+*/1 01 01 24 05 2030 echo Invalid end hour (24) for terminating task
+*/1 01 01 00 60 2030 echo Invalid end minute (60) for terminating task
+*/1 02 29 00 00 2023 echo Invalid Feb 29 for non-leap year (2023) for terminating task
+*/1 01 01 00 00 1960 echo Invalid end year (before 1970) for terminating task
+
+# Malformed lines for RecurringWithEndDateParser
+*/1 01 01 00 2030 echo Missing end_minute for terminating task
+*/1 01 01 00 00 echo Missing end_year and command for terminating task
+*/1 01 01 00 00 2030 NOCMD Missing command part (should be part of regex)
+* echo Missing all params for terminating task

--- a/src/com/schedular/ParserFactory.java
+++ b/src/com/schedular/ParserFactory.java
@@ -1,6 +1,7 @@
 package com.schedular;
 
 import java.util.List;
+import com.schedular.RecurringWithEndDateParser;
 
 /**
  * Parser Factory to create tasks based on the configured pattern.
@@ -9,6 +10,7 @@ import java.util.List;
 public class ParserFactory {
 
     private static final List<Parser> parsers = List.of(
+            new RecurringWithEndDateParser(),
             new DateTimeParser(),
             new MinutesParser()
     );

--- a/src/com/schedular/RecurringWithEndDateParser.java
+++ b/src/com/schedular/RecurringWithEndDateParser.java
@@ -1,0 +1,84 @@
+package com.schedular;
+
+import java.util.Calendar;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RecurringWithEndDateParser implements Parser {
+
+    private final Pattern pattern = Pattern.compile("^\\*/(\\d{1,4})\\s+(\\d{1,2})\\s+(\\d{1,2})\\s+(\\d{1,2})\\s+(\\d{1,2})\\s+(\\d{4})\\s+(.+)$");
+
+    @Override
+    public ExecutableTask apply(String command) throws ParserException {
+        Matcher matcher = pattern.matcher(command);
+
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        try {
+            String minutesStr = matcher.group(1);
+            String endMonthStr = matcher.group(2);
+            String endDayStr = matcher.group(3);
+            String endHourStr = matcher.group(4);
+            String endMinuteStr = matcher.group(5);
+            String endYearStr = matcher.group(6);
+            String shellCommand = matcher.group(7);
+
+            int minutes = Integer.parseInt(minutesStr);
+            int endMonth = Integer.parseInt(endMonthStr);
+            int endDay = Integer.parseInt(endDayStr);
+            int endHour = Integer.parseInt(endHourStr);
+            int endMinute = Integer.parseInt(endMinuteStr);
+            int endYear = Integer.parseInt(endYearStr);
+
+            if (minutes < 1 || minutes > 1440) {
+                throw new ParserException("Minutes must be between 1 and 1440.");
+            }
+
+            validateDateTimeComponents(endDay, endMonth, endYear, endHour, endMinute);
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.set(endYear, endMonth - 1, endDay, endHour, endMinute, 0);
+            calendar.set(Calendar.MILLISECOND, 0);
+            long endTimeMillis = calendar.getTimeInMillis();
+
+            return new TerminatingRecurringTask(minutes, endTimeMillis, shellCommand);
+
+        } catch (NumberFormatException e) {
+            throw new ParserException("Error parsing number from command: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateDateTimeComponents(int day, int month, int year, int hour, int minute) throws ParserException {
+        if (year < 1970 || year > 2100) {
+            throw new ParserException("Year must be between 1970 and 2100.");
+        }
+        if (month < 1 || month > 12) {
+            throw new ParserException("Month must be between 1 and 12.");
+        }
+        if (day < 1 || day > daysInMonth(month, year)) {
+            throw new ParserException("Invalid day for the given month and year.");
+        }
+        if (hour < 0 || hour > 23) {
+            throw new ParserException("Hour must be between 0 and 23.");
+        }
+        if (minute < 0 || minute > 59) {
+            throw new ParserException("Minute must be between 0 and 59.");
+        }
+    }
+
+    private int daysInMonth(int month, int year) {
+        if (month == 2) {
+            return isLeapYear(year) ? 29 : 28;
+        } else if (month == 4 || month == 6 || month == 9 || month == 11) {
+            return 30;
+        } else {
+            return 31;
+        }
+    }
+
+    private boolean isLeapYear(int year) {
+        return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+    }
+}

--- a/src/com/schedular/Schedular.java
+++ b/src/com/schedular/Schedular.java
@@ -2,9 +2,12 @@ package com.schedular;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -15,6 +18,7 @@ public class Schedular {
 
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
     private final List<ExecutableTask> tasks;
+    private final Map<ExecutableTask, ScheduledFuture<?>> recurringTaskFutures = new ConcurrentHashMap<>();
 
     // Default delay for one-time tasks in case of Execution time crossed already
     private static final int defaultDelay = 1000 * 60 ;
@@ -25,23 +29,42 @@ public class Schedular {
 
     public void schedule() {
         for (ExecutableTask task : tasks) {
-            Runnable taskExecutor = () -> {
-                synchronized (tasks) {
-                    System.out.println("Executing Task: " + task.getTaskType());
-                    task.execute();
-                    if(task.isCompleted()) tasks.remove(task);
-                }
-                checkAndShutdownScheduler();
-            };
-
             if (task.getTaskType() == TaskType.ONCE) {
                 long delay = Math.max(defaultDelay, task.scheduledTime().getTime() - System.currentTimeMillis());
                 System.out.println("Scheduling One-Time Task at " + ((delay == defaultDelay) ? new Date(new Date().getTime() + delay) : task.scheduledTime()));
-                scheduler.schedule(taskExecutor, delay, TimeUnit.MILLISECONDS);
+                scheduler.schedule(() -> {
+                    // This is the taskExecutor for one-time tasks
+                    synchronized (tasks) { // Keep synchronization if tasks list is modified
+                        System.out.println("Executing One-Time Task: " + task.getTaskType());
+                        task.execute();
+                        if(task.isCompleted()) tasks.remove(task);
+                    }
+                    checkAndShutdownScheduler();
+                }, delay, TimeUnit.MILLISECONDS);
             } else if (task.getTaskType() == TaskType.RECURRING) {
                 RecurringTask recurringTask = (RecurringTask) task;
-                System.out.println("Scheduling Recurring Task with delay: " + recurringTask.getDelay() + " minutes");
-                scheduler.scheduleAtFixedRate(taskExecutor, recurringTask.getDelay(), recurringTask.getDelay(), TimeUnit.MINUTES);
+                System.out.println("Scheduling Recurring Task with initial delay: " + recurringTask.getDelay() + " minutes, and period: " + recurringTask.getDelay() + " minutes");
+
+                ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(() -> {
+                    // This is the taskExecutor for recurring tasks
+                    System.out.println("Executing Recurring Task: " + task.getTaskType());
+                    task.execute(); // Execute the task first
+
+                    // Check completion *after* execution
+                    if (task.isCompleted()) {
+                        System.out.println("Recurring task " + task.getTaskType() + " has completed its lifecycle. Removing and cancelling further executions.");
+                        synchronized (tasks) { // Synchronize modifications to 'tasks' list
+                           tasks.remove(task);
+                        }
+                        ScheduledFuture<?> selfFuture = recurringTaskFutures.remove(task); // Remove from map
+                        if (selfFuture != null) {
+                            selfFuture.cancel(false); // Cancel future executions
+                        }
+                    }
+                    checkAndShutdownScheduler();
+                }, recurringTask.getDelay(), recurringTask.getDelay(), TimeUnit.MINUTES); // Initial delay and period are both getDelay()
+
+                recurringTaskFutures.put(task, future); // Store the future
             }
         }
     }
@@ -52,9 +75,30 @@ public class Schedular {
      * @see RecurringTask
      */
     private void checkAndShutdownScheduler() {
-        if (tasks.stream().allMatch(task -> task.isCompleted())) {
-            System.out.println("All tasks are completed.");
-            scheduler.shutdown();
+        synchronized (tasks) { // Ensure thread-safe access to 'tasks' list for the stream operation
+            if (tasks.stream().allMatch(ExecutableTask::isCompleted)) {
+                // This condition means all tasks *currently in the tasks list* are completed.
+                // For TerminatingRecurringTasks, they should have removed themselves from 'tasks'
+                // and cancelled their future.
+                System.out.println("All tasks in the current list are marked as completed.");
+                
+                // Check if there are any futures that are not yet 'done' (completed/cancelled).
+                // This is a safeguard. Ideally, recurringTaskFutures should be empty or all its futures should be 'done'
+                // if the corresponding tasks were removed from the 'tasks' list.
+                long activeRecurringCount = recurringTaskFutures.values().stream()
+                                               .filter(future -> !future.isDone())
+                                               .count();
+
+                if (activeRecurringCount == 0) {
+                    System.out.println("All recurring task schedules have finished. Shutting down scheduler.");
+                    scheduler.shutdown();
+                } else {
+                    System.out.println(activeRecurringCount + " recurring tasks are still scheduled. Scheduler will not shut down yet.");
+                }
+            } else {
+                // Optional: Log current task counts for debugging if not shutting down
+                // System.out.println("Scheduler check: " + tasks.size() + " tasks remaining in list.");
+            }
         }
     }
 }

--- a/src/com/schedular/TerminatingRecurringTask.java
+++ b/src/com/schedular/TerminatingRecurringTask.java
@@ -1,0 +1,43 @@
+package com.schedular;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class TerminatingRecurringTask implements RecurringTask {
+
+    private final String command;
+    private final int delay;
+    private final long endTimeMillis;
+    private TaskType taskType = TaskType.RECURRING;
+
+    public TerminatingRecurringTask(int delay, long endTimeMillis, String command) {
+        this.delay = delay;
+        this.endTimeMillis = endTimeMillis;
+        this.command = command;
+    }
+
+    @Override
+    public int getDelay() {
+        return delay;
+    }
+
+    @Override
+    public java.util.Date scheduledTime() {
+        return new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(delay));
+    }
+
+    @Override
+    public TaskType getTaskType() {
+        return taskType;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return System.currentTimeMillis() >= endTimeMillis;
+    }
+
+    @Override
+    public void execute() {
+        Executors.getExecutor().execute(this.command);
+    }
+}


### PR DESCRIPTION
This feature allows recurring tasks, defined by minute intervals, to have a specified end date and time, after which they will no longer be scheduled.

Changes include:
- New input format: `*/<minutes> <end_MM> <end_DD> <end_HH> <end_mm> <end_YYYY> <command>`
- `TerminatingRecurringTask.java`: A new task type that implements `RecurringTask` and checks if its end time has been reached.
- `RecurringWithEndDateParser.java`: A new parser to handle the new input format, including validation for date/time components.
- `ParserFactory.java`: Updated to include the new parser, prioritized over the simple recurring task parser.
- `Schedular.java`: Modified to store `ScheduledFuture` objects for recurring tasks. When a `TerminatingRecurringTask` completes (reaches its end time), its future is cancelled, and it's removed from active tasks. Shutdown logic is enhanced to consider these changes.
- Added new test cases to `resource/Input.txt` for various valid and invalid scenarios of the new task type.
- Updated `README.md` to document the new feature and its usage.